### PR TITLE
Fix user display names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,15 +7,15 @@ class User < ApplicationRecord
   validates :username,          presence: true,
                                 uniqueness: true,
                                 format: { with: /\A[a-zA-Z0-9 ]*\z/ ,
-                                          message: 'Seuls les lettres et les chiffres sont acceptés'
+                                          message: ': seuls les lettres et les chiffres sont acceptés'
                                         }
 
   validates :first_name,        format: { with: /\A[a-zA-Z0-9 ]*\z/ ,
-                                          message: 'Seuls les lettres et les chiffres sont acceptés'
+                                          message: 'Prénom : Seuls les lettres et les chiffres sont acceptés'
                                         }
-                                        
+
   validates :last_name,         format: { with: /\A[a-zA-Z0-9 ]*\z/ ,
-                                          message: 'Seuls les lettres et les chiffres sont acceptés'
+                                          message: 'Nom : Seuls les lettres et les chiffres sont acceptés'
                                         }
 
   has_many  :lessons,           dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
+  # To display user's username in the url instead of its id
   def to_param
     username
   end
@@ -45,36 +46,30 @@ class User < ApplicationRecord
   end
 
   def first_name?
-    first_name
+    first_name.nil? || first_name.split.count.zero? ? false : true
   end
 
   def display_first_name
-    if first_name?
-      first_name
-    else
-      'Pas encore de prénom !'
-    end
+    first_name? ? first_name : 'Pas encore de prénom !'
   end
 
   def last_name?
-    last_name
+    last_name.nil? || last_name.split.count.zero? ? false : true
   end
 
   def display_last_name
-    if last_name?
-      last_name
-    else
-      'Pas encore de nom !'
-    end
+    last_name? ? last_name : 'Pas encore de nom !'
+  end
+
+  def full_name
+    "#{first_name} #{last_name}"
   end
 
   def display_name
-    if first_name?
-      if last_name?
-        "#{first_name} #{last_name}"
-      else
-        first_name
-      end
+    if first_name? && last_name?
+      full_name
+    elsif first_name?
+      first_name
     else
       username
     end
@@ -90,7 +85,7 @@ class User < ApplicationRecord
   end
 
   def description?
-    description
+    description.nil? || description.split.count.zero? ? false : true
   end
 
   def display_description
@@ -152,5 +147,4 @@ class User < ApplicationRecord
   def subscription_date
     created_at.strftime("%d/%m/%Y")
   end 
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,20 +4,31 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :username,  presence: true,
-                        uniqueness: true
+  validates :username,          presence: true,
+                                uniqueness: true,
+                                format: { with: /\A[a-zA-Z0-9 ]*\z/ ,
+                                          message: 'Seuls les lettres et les chiffres sont acceptés'
+                                        }
 
-  has_many  :lessons, dependent: :destroy
-  has_many  :bookings, dependent: :destroy
-  has_many  :followed_lessons,
-            through: :bookings,
-            foreign_key: 'followed_lesson_id',
-            source: :lesson,
-            dependent: :destroy
+  validates :first_name,        format: { with: /\A[a-zA-Z0-9 ]*\z/ ,
+                                          message: 'Seuls les lettres et les chiffres sont acceptés'
+                                        }
+                                        
+  validates :last_name,         format: { with: /\A[a-zA-Z0-9 ]*\z/ ,
+                                          message: 'Seuls les lettres et les chiffres sont acceptés'
+                                        }
+
+  has_many  :lessons,           dependent: :destroy
+  has_many  :bookings,          dependent: :destroy
+  has_many  :followed_lessons,  through: :bookings,
+                                foreign_key: 'followed_lesson_id',
+                                source: :lesson,
+                                dependent: :destroy
   has_many :messages
-  has_many :chatrooms, through: :bookings, dependent: :destroy
-  has_many :schedules, dependent: :destroy
-  has_many :credit_orders, dependent: :destroy
+  has_many :chatrooms,          through: :bookings, 
+                                dependent: :destroy
+  has_many :schedules,          dependent: :destroy
+  has_many :credit_orders,      dependent: :destroy
 
   has_one_attached :avatar
 

--- a/app/views/lessons/_teacher_lesson_show_card.html.erb
+++ b/app/views/lessons/_teacher_lesson_show_card.html.erb
@@ -9,7 +9,7 @@
         <% end %>
       </div>
       <div class="mx-2 d-flex align-self-center">
-          <strong>Enseigné par <%= @lesson.teacher.display_name.titleize %></strong>
+          <strong>Enseigné par <%= @lesson.teacher.display_name.capitalize %></strong>
       </div>
     </div>
   </div>

--- a/app/views/shared/_index_cards.html.erb
+++ b/app/views/shared/_index_cards.html.erb
@@ -24,7 +24,7 @@
                 <%= image_tag "https://static.toiimg.com/photo/msid-67586673/67586673.jpg?3918697", class:"avatar mr-3 rounded-circle"%>
               <% end %>
               <div class="d-flex flex-column">
-                <strong><%= lesson.teacher.display_name.titleize %></strong>
+                <strong><%= lesson.teacher.display_name.capitalize %></strong>
                 <% if lesson.bookings.count == 1%>
                   <h6 class="card-title text-muted">1 personne a suivi ce cours !</h6>
                 <% elsif lesson.bookings.count < 1 %>

--- a/app/views/users/_edit_information_form.html.erb
+++ b/app/views/users/_edit_information_form.html.erb
@@ -29,21 +29,23 @@
 
         <div class="form-group">
           <label class="form-control-label"><strong>Prénom</strong></label>
+          <p class="text-muted"><i>Seuls les chiffres et les lettres sont acceptés</i></p>
           <div class="input-group input-group-transparent">
             <div class="input-group-prepend">
               <span class="input-group-text"><i class="fas fa-user"></i></span>
             </div>
-          <%= f.text_field :first_name, class: "form-control", placeholder: "Prénom", autocomplete: "first_name" %>
+          <%= f.text_field :first_name, class: "form-control", pattern: "^[a-zA-Z0-9]+$", placeholder: "Prénom", autocomplete: "first_name" %>
           </div>
         </div>
 
         <div class="form-group">
           <label class="form-control-label"><strong>Nom</strong></label>
+          <p class="text-muted"><i>Seuls les chiffres et les lettres sont acceptés</i></p>
           <div class="input-group input-group-transparent">
             <div class="input-group-prepend">
               <span class="input-group-text"><i class="fas fa-user"></i></span>
             </div>
-            <%= f.text_field :last_name, class: "form-control", placeholder: "Nom", autocomplete: "last_name" %>
+            <%= f.text_field :last_name, class: "form-control", pattern: "^[a-zA-Z0-9]+$", placeholder: "Nom", autocomplete: "last_name" %>
           </div>
         </div>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -9,10 +9,11 @@
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
           <%= render "users/shared/error_messages", resource: resource %>
           
-          <h1 class="h3 mb-5 font-weight-normal text-center">Edite tes informations de connexion</h1>    
+          <h1 class="h3 mb-5 font-weight-normal text-center">Edite tes informations de connexion</h1>   
 
+          <p class="text-muted"><i>Pseudo : seuls les chiffres et les lettres sont acceptés</i></p>
           <div class="form-group">
-            <%= f.text_field :username, autofocus: true, class: "form-control", placeholder: "Pseudonyme",autocomplete: "username", required: true %>
+            <%= f.text_field :username, autofocus: true, class: "form-control", pattern: "^[a-zA-Z0-9]+$", placeholder: "Pseudonyme",autocomplete: "username", required: true %>
           </div>
 
           <div class="form-group">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -14,11 +14,12 @@
 
               <div class="form-group">
                 <label class="form-control-label"><strong>Pseudonyme</strong></label>
+                <p class="text-muted"><i>Seuls les chiffres et les lettres sont acceptés</i></p>
                 <div class="input-group input-group-transparent">
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-user"></i></span>
                   </div>
-                  <%= f.text_field :username, autofocus: true, class: "form-control", placeholder: "Jeanmich", required: true %>
+                  <%= f.text_field :username, autofocus: true, class: "form-control", pattern: "^[a-zA-Z0-9]+$", placeholder: "Jeanmich", required: true %>
                 </div>
               </div>
 


### PR DESCRIPTION
Ajoute des restrictions de caractères spéciaux pour les pseudo, nom et prénom dans le model et les views (en JS). Le message JS des views n'étant pas explicite, j'ai ajouté une indication sur les pages où sont demandées ces infos.